### PR TITLE
Add Visual Studio / MsBuild 2017 support

### DIFF
--- a/Invoke-MsBuild/Invoke-MsBuild.psd1
+++ b/Invoke-MsBuild/Invoke-MsBuild.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Invoke-MsBuild.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.2.0'
+ModuleVersion = '2.3.0'
 
 # ID used to uniquely identify this module
 GUID = '8ca20938-b92a-42a1-bf65-f644e16a8d9e'
@@ -104,8 +104,7 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        ReleaseNotes = '- Added LogVerbosityLevel parameter to adjust the verbosity MsBuild uses to write to the log file.
-- Fixed bug that prevented us from finding msbuild.exe on some machines.
+        ReleaseNotes = '- Added support for VS/MsBuild 2017.
 
 ----------
 Invoke-MsBuild v2 has the following breaking changes from v1:

--- a/Invoke-MsBuild/Invoke-MsBuild.psm1
+++ b/Invoke-MsBuild/Invoke-MsBuild.psm1
@@ -183,7 +183,7 @@ function Invoke-MsBuild
 	.NOTES
 	Name:   Invoke-MsBuild
 	Author: Daniel Schroeder (originally based on the module at http://geekswithblogs.net/dwdii/archive/2011/05/27/part-2-automating-a-visual-studio-build-with-powershell.aspx)
-	Version: 2.2.0
+	Version: 2.3.0
 #>
 	[CmdletBinding(DefaultParameterSetName="Wait")]
 	param

--- a/Tests/RunTests.ps1
+++ b/Tests/RunTests.ps1
@@ -4,7 +4,7 @@
 Set-StrictMode -Version Latest
 
 # Clear the screen before running our tests.
-cls
+Clear-Host
 
 # Get the directory that this script is in.
 $THIS_SCRIPTS_DIRECTORY = Split-Path $script:MyInvocation.MyCommand.Path
@@ -12,8 +12,8 @@ $THIS_SCRIPTS_DIRECTORY = Split-Path $script:MyInvocation.MyCommand.Path
 # Import Invoke-MsBuild. Use -Force to make sure we reload it in case we have been making changes to it.
 Import-Module -Name (Join-Path (Join-Path (Split-Path -Path $THIS_SCRIPTS_DIRECTORY -Parent) 'Invoke-MsBuild') 'Invoke-MsBuild.psm1') -Force
 
-$pathToGoodSolution = (Join-Path $THIS_SCRIPTS_DIRECTORY "SolutionThatShouldBuildSuccessfully\SolutionThatShouldBuildSuccessfully.sln")
-$pathToBrokenSolution = (Join-Path $THIS_SCRIPTS_DIRECTORY "SolutionThatShouldFailBuild\SolutionThatShouldFailBuild.sln")
+$pathToGoodSolution = (Join-Path $THIS_SCRIPTS_DIRECTORY "Solution That Should Build Successfully\SolutionThatShouldBuildSuccessfully.sln")
+$pathToBrokenSolution = (Join-Path $THIS_SCRIPTS_DIRECTORY "Solution That Should Fail Build\SolutionThatShouldFailBuild.sln")
 $invalidPath = (Join-Path $THIS_SCRIPTS_DIRECTORY "invalid\path")
 
 $testNumber = 0


### PR DESCRIPTION
- Adds the ability to locate the MsBuild.exe included with VS 2017.
- Fixes problem with Tests that was missed on a previous commit to test solutions with spaces in the path.
- Bump the version number from 2.2.0 to 2.3.0, and published new NuGet package.