### PR TITLE
feature: Return BuildDuration as part of the result set

### DIFF
--- a/src/Tests/RunTests.ps1
+++ b/src/Tests/RunTests.ps1
@@ -39,6 +39,9 @@ if ((Invoke-MsBuild -Path $pathToBrokenSolution).BuildSucceeded -eq $false) { Wr
 Write-Host ("{0}. Using -WhatIf switch... Should see object's properties and values." -f ++$testNumber)
 Invoke-MsBuild -Path $pathToGoodSolution -WhatIf
 
+Write-Host ("{0}. Build solution... Should see object's properties and values." -f ++$testNumber)
+Invoke-MsBuild -Path $pathToGoodSolution
+
 Write-Host ("{0}. Using -PassThru switch... Should see a few building messages." -f ++$testNumber)
 $process = Invoke-MsBuild -Path $pathToGoodSolution -PassThru	
 while (!$process.HasExited)


### PR DESCRIPTION
- Measure how long the build takes to complete and return it as one of the result properties.
- Add test to also display the properties on a successful build so we can see what they look like typically.