### PR TITLE
feature: Add BypassVisualStudioDeveloperCommandPrompt parameter

### DIFF
--- a/src/Tests/RunTests.ps1
+++ b/src/Tests/RunTests.ps1
@@ -29,6 +29,9 @@ if ((Invoke-MsBuild -Path $pathToWarningSolution).BuildSucceeded -eq $true) { Wr
 Write-Host ("{0}. Build solution using 32-bit MsBuild..." -f ++$testNumber)
 if ((Invoke-MsBuild -Path $pathToGoodSolution -Use32BitMsBuild).BuildSucceeded -eq $true) { Write-Host "Passed" } else { throw "Test $testNumber failed." }
 
+Write-Host ("{0}. Build solution witout using the VS Developer Command Prompt..." -f ++$testNumber)
+if ((Invoke-MsBuild -Path $pathToGoodSolution -BypassVisualStudioDeveloperCommandPrompt).BuildSucceeded -eq $true) { Write-Host "Passed" } else { throw "Test $testNumber failed." }
+
 Write-Host ("{0}. Build solution via piping..." -f ++$testNumber)
 if (($pathToGoodSolution | Invoke-MsBuild).BuildSucceeded -eq $true) { Write-Host "Passed" } else { throw "Test $testNumber failed." }
 


### PR DESCRIPTION
This switch parameter allows us to not use the Visual Studio Developer Command Prompt and instead call MsBuild directly, in order to work around potential performance problems from calling the VS Dev Command Prompt.