### PR TITLE
Fixed MsBuild hanging

### DIFF
--- a/src/Invoke-MsBuild/Invoke-MsBuild.psm1
+++ b/src/Invoke-MsBuild/Invoke-MsBuild.psm1
@@ -331,12 +331,6 @@ function Invoke-MsBuild
 			# Build the arguments to pass to MsBuild.
 			$buildArguments = """$Path"" $MsBuildParameters /fileLoggerParameters:LogFile=""$buildLogFilePath""$verbosityLevel /fileLoggerParameters1:LogFile=""$buildErrorsLogFilePath"";errorsonly"
 
-			# If the user hasn't set the UseSharedCompilation mode explicitly, turn it off (it's on by default, but can cause MsBuild to hang for some reason).
-			if ($buildArguments -notlike '*UseSharedCompilation*')
-			{
-				$buildArguments += " /p:UseSharedCompilation=false " # prevent processes from hanging (Roslyn compiler?)
-			}
-
 			# Get the path to the MsBuild executable.
 			$msBuildPath = $MsBuildFilePath
 			[bool] $msBuildPathWasNotProvided = [string]::IsNullOrEmpty($msBuildPath)
@@ -415,12 +409,14 @@ function Invoke-MsBuild
 				{
 					if ($ShowBuildOutputInCurrentWindow)
 					{
-						$result.MsBuildProcess = Start-Process cmd.exe -ArgumentList $cmdArgumentsToRunMsBuild -NoNewWindow -Wait -PassThru
+						$result.MsBuildProcess = Start-Process cmd.exe -ArgumentList $cmdArgumentsToRunMsBuild -NoNewWindow -PassThru
 					}
 					else
 					{
-						$result.MsBuildProcess = Start-Process cmd.exe -ArgumentList $cmdArgumentsToRunMsBuild -WindowStyle $windowStyleOfNewWindow -Wait -PassThru
+						$result.MsBuildProcess = Start-Process cmd.exe -ArgumentList $cmdArgumentsToRunMsBuild -WindowStyle $windowStyleOfNewWindow -PassThru
 					}
+					
+					Wait-Process -InputObject $result.MsBuildProcess
 				}
 
 				# Perform the build and record how long it takes.


### PR DESCRIPTION
The `-Wait` flag or `Start-Process` will wait for all child processes that in this case will include the msbuild build server started in the background.
Replacing the process waiting with Wait-Process and providing the exact `cmd.exe` process fixes this issue.

Should fix the hang mentioned in #32.